### PR TITLE
Alternate adaptation w.r.t. coq/coq#16004 and coq/coq#16258

### DIFF
--- a/PerformanceExperiments/Harness.v
+++ b/PerformanceExperiments/Harness.v
@@ -283,15 +283,19 @@ Proof.
   intros x y; specialize (Hr x y); destruct Hr; intuition (eauto; congruence).
 Qed.
 
+#[global]
 Instance reflect_eq_nat : reflect_rel (@eq nat) Nat.eqb
   := reflect_rel_of_beq_iff Nat.eqb_eq.
 
+#[global]
 Instance reflect_eq_N : reflect_rel (@eq N) N.eqb
   := reflect_rel_of_beq_iff N.eqb_eq.
 
+#[global]
 Instance reflect_eq_positive : reflect_rel (@eq positive) Pos.eqb
   := reflect_rel_of_beq_iff Pos.eqb_eq.
 
+#[global]
 Instance reflect_eq_Z : reflect_rel (@eq Z) Z.eqb
   := reflect_rel_of_beq_iff Z.eqb_eq.
 
@@ -308,24 +312,33 @@ Proof.
 Defined.
 Local Unset Implicit Arguments.
 
+#[global]
 Instance reflect_eq_prod {A B eqA eqB} {_ : reflect_rel (@eq A) eqA} {_ : reflect_rel (@eq B) eqB}
   : reflect_rel (@eq (A * B)) (prod_beq eqA eqB)
   := reflect_rel_of_beq_iff (prod_beq_iff (reflect_rel_to_beq_iff _) (reflect_rel_to_beq_iff _)).
 
 Class has_sub T := sub : T -> T -> T.
+#[global]
 Instance: has_sub nat := Nat.sub.
+#[global]
 Instance: has_sub Z := Z.sub.
 
 Class has_succ T := succ : T -> T.
+#[global]
 Instance: has_succ nat := S.
+#[global]
 Instance: has_succ Z := Z.succ.
 
 Class has_zero T := zero : T.
+#[global]
 Instance: has_zero nat := O.
+#[global]
 Instance: has_zero Z := Z0.
 
 Class has_sort T := sort : list T -> list T.
+#[global]
 Instance: has_sort nat := NatSort.sort.
+#[global]
 Instance: has_sort Z := ZSort.sort.
 
 Definition remove_smaller_args_of_size_by_reflect

--- a/PerformanceExperiments/Harness.v
+++ b/PerformanceExperiments/Harness.v
@@ -283,20 +283,16 @@ Proof.
   intros x y; specialize (Hr x y); destruct Hr; intuition (eauto; congruence).
 Qed.
 
-#[global]
-Instance reflect_eq_nat : reflect_rel (@eq nat) Nat.eqb
+Global Instance reflect_eq_nat : reflect_rel (@eq nat) Nat.eqb
   := reflect_rel_of_beq_iff Nat.eqb_eq.
 
-#[global]
-Instance reflect_eq_N : reflect_rel (@eq N) N.eqb
+Global Instance reflect_eq_N : reflect_rel (@eq N) N.eqb
   := reflect_rel_of_beq_iff N.eqb_eq.
 
-#[global]
-Instance reflect_eq_positive : reflect_rel (@eq positive) Pos.eqb
+Global Instance reflect_eq_positive : reflect_rel (@eq positive) Pos.eqb
   := reflect_rel_of_beq_iff Pos.eqb_eq.
 
-#[global]
-Instance reflect_eq_Z : reflect_rel (@eq Z) Z.eqb
+Global Instance reflect_eq_Z : reflect_rel (@eq Z) Z.eqb
   := reflect_rel_of_beq_iff Z.eqb_eq.
 
 Local Set Implicit Arguments.
@@ -312,34 +308,25 @@ Proof.
 Defined.
 Local Unset Implicit Arguments.
 
-#[global]
-Instance reflect_eq_prod {A B eqA eqB} {_ : reflect_rel (@eq A) eqA} {_ : reflect_rel (@eq B) eqB}
+Global Instance reflect_eq_prod {A B eqA eqB} {_ : reflect_rel (@eq A) eqA} {_ : reflect_rel (@eq B) eqB}
   : reflect_rel (@eq (A * B)) (prod_beq eqA eqB)
   := reflect_rel_of_beq_iff (prod_beq_iff (reflect_rel_to_beq_iff _) (reflect_rel_to_beq_iff _)).
 
 Class has_sub T := sub : T -> T -> T.
-#[global]
-Instance: has_sub nat := Nat.sub.
-#[global]
-Instance: has_sub Z := Z.sub.
+Global Instance: has_sub nat := Nat.sub.
+Global Instance: has_sub Z := Z.sub.
 
 Class has_succ T := succ : T -> T.
-#[global]
-Instance: has_succ nat := S.
-#[global]
-Instance: has_succ Z := Z.succ.
+Global Instance: has_succ nat := S.
+Global Instance: has_succ Z := Z.succ.
 
 Class has_zero T := zero : T.
-#[global]
-Instance: has_zero nat := O.
-#[global]
-Instance: has_zero Z := Z0.
+Global Instance: has_zero nat := O.
+Global Instance: has_zero Z := Z0.
 
 Class has_sort T := sort : list T -> list T.
-#[global]
-Instance: has_sort nat := NatSort.sort.
-#[global]
-Instance: has_sort Z := ZSort.sort.
+Global Instance: has_sort nat := NatSort.sort.
+Global Instance: has_sort Z := ZSort.sort.
 
 Definition remove_smaller_args_of_size_by_reflect
            {T} {T_beq : T -> T -> bool}

--- a/PerformanceExperiments/Makefile
+++ b/PerformanceExperiments/Makefile
@@ -23,7 +23,7 @@ include Makefile.variables
 all:: invoke-coqmakefile
 .PHONY: all
 
-WARNINGS:=-notation-overridden,-undeclared-scope
+WARNINGS:=-notation-overridden,-undeclared-scope,-deprecated-hint-rewrite-without-locality,-deprecated-typeclasses-transparency-without-locality
 
 ifneq ($(wildcard ../.git),)
 FILE_FINDER := git ls-files

--- a/PerformanceExperiments/PrimitiveProd.v
+++ b/PerformanceExperiments/PrimitiveProd.v
@@ -65,6 +65,7 @@ Local Arguments f_equal {_ _} _ {_ _} _.
 
 Definition fst_pair {A B} (a:A) (b:B) : fst (a,b) = a := eq_refl.
 Definition snd_pair {A B} (a:A) (b:B) : snd (a,b) = b := eq_refl.
+#[global]
 Create HintDb cancel_primpair discriminated. Hint Rewrite @fst_pair @snd_pair : cancel_primpair.
 
 (** ** Equality for [prod] *)
@@ -127,6 +128,7 @@ Proof. repeat (intros [? ?] || intro || split); assumption. Defined.
 Global Instance iff_prod_Proper
   : Proper (iff ==> iff ==> iff) (fun A B => prod A B).
 Proof. repeat intro; tauto. Defined.
+#[global]
 Hint Extern 2 (Proper _ (fun A B => prod A B)) => refine iff_prod_Proper : typeclass_instances.
 
 (** ** Useful Tactics *)

--- a/PerformanceExperiments/PrimitiveProd.v
+++ b/PerformanceExperiments/PrimitiveProd.v
@@ -65,8 +65,6 @@ Local Arguments f_equal {_ _} _ {_ _} _.
 
 Definition fst_pair {A B} (a:A) (b:B) : fst (a,b) = a := eq_refl.
 Definition snd_pair {A B} (a:A) (b:B) : snd (a,b) = b := eq_refl.
-#[global]
-Create HintDb cancel_primpair discriminated. Hint Rewrite @fst_pair @snd_pair : cancel_primpair.
 
 (** ** Equality for [prod] *)
 Section prod.
@@ -128,8 +126,7 @@ Proof. repeat (intros [? ?] || intro || split); assumption. Defined.
 Global Instance iff_prod_Proper
   : Proper (iff ==> iff ==> iff) (fun A B => prod A B).
 Proof. repeat intro; tauto. Defined.
-#[global]
-Hint Extern 2 (Proper _ (fun A B => prod A B)) => refine iff_prod_Proper : typeclass_instances.
+Global Hint Extern 2 (Proper _ (fun A B => prod A B)) => refine iff_prod_Proper : typeclass_instances.
 
 (** ** Useful Tactics *)
 (** *** [inversion_prod] *)

--- a/PerformanceExperiments/Reify/TypeClasses.v
+++ b/PerformanceExperiments/Reify/TypeClasses.v
@@ -25,7 +25,9 @@ Module TypeClasses.
     infer reifications if it doesn't fully know what term it's
     reifying. *)
 
+#[global]
   Hint Mode reify_of - ! - : typeclass_instances.
+#[global]
   Hint Opaque Nat.mul Let_In : typeclass_instances.
 
   Ltac reify var x :=
@@ -98,7 +100,9 @@ Module TypeClassesBodyHOAS.
     infer reifications if it doesn't fully know what term it's
     reifying. *)
 
+#[global]
   Hint Mode reify_of ! : typeclass_instances.
+#[global]
   Hint Opaque Nat.mul Let_In : typeclass_instances.
 
   Ltac Reify x :=
@@ -159,7 +163,9 @@ Module TypeClassesBodyFlatPHOAS.
     infer reifications if it doesn't fully know what term it's
     reifying. *)
 
+#[global]
   Hint Mode reify_of - ! : typeclass_instances.
+#[global]
   Hint Opaque Nat.mul : typeclass_instances.
 
   Ltac reify var x :=

--- a/PerformanceExperiments/Reify/TypeClasses.v
+++ b/PerformanceExperiments/Reify/TypeClasses.v
@@ -25,10 +25,9 @@ Module TypeClasses.
     infer reifications if it doesn't fully know what term it's
     reifying. *)
 
-#[global]
-  Hint Mode reify_of - ! - : typeclass_instances.
-#[global]
-  Hint Opaque Nat.mul Let_In : typeclass_instances.
+
+  Global Hint Mode reify_of - ! - : typeclass_instances.
+  Global Hint Opaque Nat.mul Let_In : typeclass_instances.
 
   Ltac reify var x :=
     let c := constr:(_ : @reify_of var x _) in
@@ -100,10 +99,8 @@ Module TypeClassesBodyHOAS.
     infer reifications if it doesn't fully know what term it's
     reifying. *)
 
-#[global]
-  Hint Mode reify_of ! : typeclass_instances.
-#[global]
-  Hint Opaque Nat.mul Let_In : typeclass_instances.
+  Global Hint Mode reify_of ! : typeclass_instances.
+  Global Hint Opaque Nat.mul Let_In : typeclass_instances.
 
   Ltac Reify x :=
     constr:(_ : @reify_of x).
@@ -163,10 +160,8 @@ Module TypeClassesBodyFlatPHOAS.
     infer reifications if it doesn't fully know what term it's
     reifying. *)
 
-#[global]
-  Hint Mode reify_of - ! : typeclass_instances.
-#[global]
-  Hint Opaque Nat.mul : typeclass_instances.
+  Global Hint Mode reify_of - ! : typeclass_instances.
+  Global Hint Opaque Nat.mul : typeclass_instances.
 
   Ltac reify var x :=
     constr:(_ : @reify_of var x).

--- a/PerformanceExperiments/Sample.v
+++ b/PerformanceExperiments/Sample.v
@@ -677,6 +677,7 @@ Class factors_through_prod {T} (f : N * N -> T) :=
     ; factor_correctness : forall x, f x = factor_through_prod (fst x * snd x)%N }.
 Arguments factor_through_prod {T} f {_}.
 
+#[global]
 Hint Unfold id : solve_factors_through_prod.
 
 Ltac subst_context_vars f :=
@@ -753,9 +754,12 @@ Definition small_table (* the [n]th element is the number of ways there are to w
          => (n:N, ∑_{i=1}^{n} if (n mod i =? 0) then 1 else 0)%Z)
         (seq 0 (Z.to_nat (1 + cutoff))).
 
+#[global]
 Hint Extern 0 (reified ?f) => let v := reify_poly f in exact v : typeclass_instances.
 
+#[global]
 Hint Extern 0 (factors_through_prod _) => solve_factors_through_prod : typeclass_instances.
+#[global]
 Hint Extern 0 => progress unfold factor_through_prod : typeclass_instances.
 
 Global Instance nat_has_double_avg : has_double_avg nat
@@ -896,6 +900,7 @@ Definition total_time_of_Zpoly
         if (max - min <=? 25)%Z
         then ∑_{i=min}^{max} (size i)
         else f_int max - f_int min.
+#[global]
 Hint Extern 0 (has_total_time Z) => simple eapply @total_time_of_Zpoly : typeclass_instances.
 
 Definition total_time_of_Npoly
@@ -903,6 +908,7 @@ Definition total_time_of_Npoly
        {p : reified (fun x => size (Z.to_N x))}
   : has_total_time N
   := fun min max => @total_time_of_Zpoly _ p min max.
+#[global]
 Hint Extern 0 (has_total_time N) => simple eapply @total_time_of_Npoly : typeclass_instances.
 
 Definition total_time_of_nat_poly
@@ -910,6 +916,7 @@ Definition total_time_of_nat_poly
        {p : reified (fun x => size (N.to_nat (Z.to_N x)))}
   : has_total_time nat
   := fun min max => @total_time_of_Zpoly _ p min max.
+#[global]
 Hint Extern 0 (has_total_time nat) => simple eapply @total_time_of_nat_poly : typeclass_instances.
 
 Fixpoint make_cumulants'
@@ -990,6 +997,7 @@ Definition total_time_of_N_prod_poly
        {p : reified (fun x:Z => factor_through_prod size (Z.to_N x))}
   : has_total_time (N * N)
   := dlet cached_table := small_table_rev_cached in total_time_of_N_prod_poly_cached cached_table.
+#[global]
 Hint Extern 0 (has_total_time (N * N)) => simple eapply @total_time_of_N_prod_poly : typeclass_instances.
 
 Definition total_time_of_Z_prod_poly_cached
@@ -1007,6 +1015,7 @@ Definition total_time_of_Z_prod_poly
        {p : reified (fun x => factor_through_prod size' (Z.to_N x))}
   : has_total_time (Z * Z)
   := dlet cached_table := @small_table_rev_cached size' in total_time_of_Z_prod_poly_cached cached_table.
+#[global]
 Hint Extern 0 (has_total_time (Z * Z)) => simple eapply @total_time_of_Z_prod_poly : typeclass_instances.
 
 Definition total_time_of_nat_prod_poly_cached
@@ -1024,10 +1033,12 @@ Definition total_time_of_nat_prod_poly
        {p : reified (fun x => factor_through_prod size' (Z.to_nat x))}
   : has_total_time (nat * nat)
   := dlet cached_table := @small_table_rev_cached size' in total_time_of_nat_prod_poly_cached cached_table.
+#[global]
 Hint Extern 0 (has_total_time (nat * nat)) => simple eapply @total_time_of_nat_prod_poly : typeclass_instances.
 
 Class with_assum {T} (v : T) (T' : Type) := val : T'.
 
+#[global]
 Hint Extern 0 (@with_assum ?T ?v ?T') => pose (v : T); change T' : typeclass_instances.
 
 Class has_compress {A B} := compress_T : A -> B.

--- a/PerformanceExperiments/Sample.v
+++ b/PerformanceExperiments/Sample.v
@@ -677,8 +677,7 @@ Class factors_through_prod {T} (f : N * N -> T) :=
     ; factor_correctness : forall x, f x = factor_through_prod (fst x * snd x)%N }.
 Arguments factor_through_prod {T} f {_}.
 
-#[global]
-Hint Unfold id : solve_factors_through_prod.
+Global Hint Unfold id : solve_factors_through_prod.
 
 Ltac subst_context_vars f :=
   let run := match goal with
@@ -754,13 +753,10 @@ Definition small_table (* the [n]th element is the number of ways there are to w
          => (n:N, ∑_{i=1}^{n} if (n mod i =? 0) then 1 else 0)%Z)
         (seq 0 (Z.to_nat (1 + cutoff))).
 
-#[global]
-Hint Extern 0 (reified ?f) => let v := reify_poly f in exact v : typeclass_instances.
+Global Hint Extern 0 (reified ?f) => let v := reify_poly f in exact v : typeclass_instances.
 
-#[global]
-Hint Extern 0 (factors_through_prod _) => solve_factors_through_prod : typeclass_instances.
-#[global]
-Hint Extern 0 => progress unfold factor_through_prod : typeclass_instances.
+Global Hint Extern 0 (factors_through_prod _) => solve_factors_through_prod : typeclass_instances.
+Global Hint Extern 0 => progress unfold factor_through_prod : typeclass_instances.
 
 Global Instance nat_has_double_avg : has_double_avg nat
   := { double_T := Nat.mul 2 ; avg_T x y := ((x + y) / 2)%nat }.
@@ -900,24 +896,21 @@ Definition total_time_of_Zpoly
         if (max - min <=? 25)%Z
         then ∑_{i=min}^{max} (size i)
         else f_int max - f_int min.
-#[global]
-Hint Extern 0 (has_total_time Z) => simple eapply @total_time_of_Zpoly : typeclass_instances.
+Global Hint Extern 0 (has_total_time Z) => simple eapply @total_time_of_Zpoly : typeclass_instances.
 
 Definition total_time_of_Npoly
        {size : has_size N}
        {p : reified (fun x => size (Z.to_N x))}
   : has_total_time N
   := fun min max => @total_time_of_Zpoly _ p min max.
-#[global]
-Hint Extern 0 (has_total_time N) => simple eapply @total_time_of_Npoly : typeclass_instances.
+Global Hint Extern 0 (has_total_time N) => simple eapply @total_time_of_Npoly : typeclass_instances.
 
 Definition total_time_of_nat_poly
        {size : has_size nat}
        {p : reified (fun x => size (N.to_nat (Z.to_N x)))}
   : has_total_time nat
   := fun min max => @total_time_of_Zpoly _ p min max.
-#[global]
-Hint Extern 0 (has_total_time nat) => simple eapply @total_time_of_nat_poly : typeclass_instances.
+Global Hint Extern 0 (has_total_time nat) => simple eapply @total_time_of_nat_poly : typeclass_instances.
 
 Fixpoint make_cumulants'
          {T} (add : T -> T -> T) (acc : T) (ls : list T)
@@ -997,8 +990,7 @@ Definition total_time_of_N_prod_poly
        {p : reified (fun x:Z => factor_through_prod size (Z.to_N x))}
   : has_total_time (N * N)
   := dlet cached_table := small_table_rev_cached in total_time_of_N_prod_poly_cached cached_table.
-#[global]
-Hint Extern 0 (has_total_time (N * N)) => simple eapply @total_time_of_N_prod_poly : typeclass_instances.
+Global Hint Extern 0 (has_total_time (N * N)) => simple eapply @total_time_of_N_prod_poly : typeclass_instances.
 
 Definition total_time_of_Z_prod_poly_cached
        {size : has_size (Z * Z)}
@@ -1015,8 +1007,7 @@ Definition total_time_of_Z_prod_poly
        {p : reified (fun x => factor_through_prod size' (Z.to_N x))}
   : has_total_time (Z * Z)
   := dlet cached_table := @small_table_rev_cached size' in total_time_of_Z_prod_poly_cached cached_table.
-#[global]
-Hint Extern 0 (has_total_time (Z * Z)) => simple eapply @total_time_of_Z_prod_poly : typeclass_instances.
+Global Hint Extern 0 (has_total_time (Z * Z)) => simple eapply @total_time_of_Z_prod_poly : typeclass_instances.
 
 Definition total_time_of_nat_prod_poly_cached
        {size : has_size (nat * nat)}
@@ -1033,13 +1024,11 @@ Definition total_time_of_nat_prod_poly
        {p : reified (fun x => factor_through_prod size' (Z.to_nat x))}
   : has_total_time (nat * nat)
   := dlet cached_table := @small_table_rev_cached size' in total_time_of_nat_prod_poly_cached cached_table.
-#[global]
-Hint Extern 0 (has_total_time (nat * nat)) => simple eapply @total_time_of_nat_prod_poly : typeclass_instances.
+Global Hint Extern 0 (has_total_time (nat * nat)) => simple eapply @total_time_of_nat_prod_poly : typeclass_instances.
 
 Class with_assum {T} (v : T) (T' : Type) := val : T'.
 
-#[global]
-Hint Extern 0 (@with_assum ?T ?v ?T') => pose (v : T); change T' : typeclass_instances.
+Global Hint Extern 0 (@with_assum ?T ?v ?T') => pose (v : T); change T' : typeclass_instances.
 
 Class has_compress {A B} := compress_T : A -> B.
 Global Arguments has_compress : clear implicits.

--- a/PerformanceExperiments/rewrite_lift_lets_map.v
+++ b/PerformanceExperiments/rewrite_lift_lets_map.v
@@ -59,9 +59,11 @@ Definition make_cps {T} (n : nat) (m : nat) (v : Z) (k : list Z -> T)
 Lemma lift_let_list_rect T A P N C (v : A) fls
   : @list_rect T P N C (Let_In v fls) = Let_In v (fun v => @list_rect T P N C (fls v)).
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite lift_let_list_rect : mydb2.
 Lemma lift_let_cons T A x (v : A) f : @cons T x (Let_In v f) = Let_In v (fun v => @cons T x (f v)).
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite lift_let_cons : mydb1.
 
 Notation goal n m := (forall v, make n m v = nil) (only parsing).
@@ -338,6 +340,7 @@ Ltac mkgoal8 := mkgoal constr:(kind_red simpl).
 Ltac time_solve_goal8 := time_solve_goal constr:(kind_red simpl).
 Ltac run8 sz := Harness.runtests_verify_sanity (args_of_size (kind_red simpl)) describe_goal mkgoal8 redgoal time_solve_goal8 verify sz.
 
+#[global]
 Hint Opaque Let_In : rewrite typeclass_instances.
 Global Opaque Let_In.
 Global Instance : forall {A}, Proper (eq ==> eq ==> Basics.flip Basics.impl) (@eq A) := _.

--- a/PerformanceExperiments/rewrite_lift_lets_map.v
+++ b/PerformanceExperiments/rewrite_lift_lets_map.v
@@ -59,11 +59,9 @@ Definition make_cps {T} (n : nat) (m : nat) (v : Z) (k : list Z -> T)
 Lemma lift_let_list_rect T A P N C (v : A) fls
   : @list_rect T P N C (Let_In v fls) = Let_In v (fun v => @list_rect T P N C (fls v)).
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite lift_let_list_rect : mydb2.
 Lemma lift_let_cons T A x (v : A) f : @cons T x (Let_In v f) = Let_In v (fun v => @cons T x (f v)).
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite lift_let_cons : mydb1.
 
 Notation goal n m := (forall v, make n m v = nil) (only parsing).
@@ -340,8 +338,7 @@ Ltac mkgoal8 := mkgoal constr:(kind_red simpl).
 Ltac time_solve_goal8 := time_solve_goal constr:(kind_red simpl).
 Ltac run8 sz := Harness.runtests_verify_sanity (args_of_size (kind_red simpl)) describe_goal mkgoal8 redgoal time_solve_goal8 verify sz.
 
-#[global]
-Hint Opaque Let_In : rewrite typeclass_instances.
+Global Hint Opaque Let_In : rewrite typeclass_instances.
 Global Opaque Let_In.
 Global Instance : forall {A}, Proper (eq ==> eq ==> Basics.flip Basics.impl) (@eq A) := _.
 Global Instance : Proper (eq ==> eq)

--- a/PerformanceExperiments/rewrite_plus_0_tree.v
+++ b/PerformanceExperiments/rewrite_plus_0_tree.v
@@ -342,7 +342,6 @@ Ltac describe_goal nm :=
        idtac "Params: 0-nm=" sz ", 1-n=" n ", 2-m=" m ", 3-input-size=" input_num_nodes ", 4-output-size=" output_num_nodes ", 5-num-rewrites=" num_rewrites
   end.
 
-#[global]
 Hint Rewrite Z.add_0_r : mydb.
 
 Ltac do_coq_rewrite _ := rewrite -> !Z.add_0_r.
@@ -420,8 +419,7 @@ Ltac mkgoal5 := mkgoal constr:(kind_autorewrite).
 Ltac time_solve_goal5 := time_solve_goal constr:(kind_autorewrite).
 Ltac run5 sz := Harness.runtests_verify_sanity (args_of_size (kind_autorewrite)) describe_goal mkgoal5 redgoal time_solve_goal5 verify sz.
 
-#[global]
-Hint Opaque Z.add : rewrite typeclass_instances.
+Global Hint Opaque Z.add : rewrite typeclass_instances.
 Global Opaque Z.add.
 
 Global Instance : forall {A}, Proper (eq ==> eq ==> Basics.flip Basics.impl) (@eq A) := _.

--- a/PerformanceExperiments/rewrite_plus_0_tree.v
+++ b/PerformanceExperiments/rewrite_plus_0_tree.v
@@ -342,6 +342,7 @@ Ltac describe_goal nm :=
        idtac "Params: 0-nm=" sz ", 1-n=" n ", 2-m=" m ", 3-input-size=" input_num_nodes ", 4-output-size=" output_num_nodes ", 5-num-rewrites=" num_rewrites
   end.
 
+#[global]
 Hint Rewrite Z.add_0_r : mydb.
 
 Ltac do_coq_rewrite _ := rewrite -> !Z.add_0_r.
@@ -419,6 +420,7 @@ Ltac mkgoal5 := mkgoal constr:(kind_autorewrite).
 Ltac time_solve_goal5 := time_solve_goal constr:(kind_autorewrite).
 Ltac run5 sz := Harness.runtests_verify_sanity (args_of_size (kind_autorewrite)) describe_goal mkgoal5 redgoal time_solve_goal5 verify sz.
 
+#[global]
 Hint Opaque Z.add : rewrite typeclass_instances.
 Global Opaque Z.add.
 

--- a/PerformanceExperiments/rewrite_repeated_app_common.v
+++ b/PerformanceExperiments/rewrite_repeated_app_common.v
@@ -11,6 +11,7 @@ Axiom f' : nat -> nat -> nat.
 Axiom g' : nat -> nat -> nat.
 Axiom f'g' : forall x y, f' x y = g' x y.
 
+#[global]
 Hint Rewrite fg : rew_fg.
 
 Fixpoint comp_pow {A} (f : A -> A) (n : nat) (x : A) {struct n} : A

--- a/PerformanceExperiments/rewrite_repeated_app_common.v
+++ b/PerformanceExperiments/rewrite_repeated_app_common.v
@@ -11,7 +11,6 @@ Axiom f' : nat -> nat -> nat.
 Axiom g' : nat -> nat -> nat.
 Axiom f'g' : forall x y, f' x y = g' x y.
 
-#[global]
 Hint Rewrite fg : rew_fg.
 
 Fixpoint comp_pow {A} (f : A -> A) (n : nat) (x : A) {struct n} : A

--- a/PerformanceExperiments/rewrite_under_binders_common.v
+++ b/PerformanceExperiments/rewrite_under_binders_common.v
@@ -17,6 +17,7 @@ Module Type LetInT.
   Notation "'dlet' x .. y := v 'in' f" := (Let_In v (fun x => .. (fun y => f) .. )).
   Axiom Let_In_nd_Proper : forall {A P},
       Proper (eq ==> pointwise_relation _ eq ==> eq) (@Let_In A (fun _ => P)).
+#[global]
   Hint Extern 0 (Proper _ (@Let_In _ _)) => simple apply @Let_In_nd_Proper : typeclass_instances.
 End LetInT.
 
@@ -26,6 +27,7 @@ Module Export LetIn : LetInT.
   Lemma Let_In_def : @Let_In = fun A P x f => let y := x in f y.
   Proof. reflexivity. Qed.
   Global Strategy 100 [Let_In].
+#[global]
   Hint Opaque Let_In : rewrite.
   Global Instance Let_In_nd_Proper {A P}
     : Proper (eq ==> pointwise_relation _ eq ==> eq) (@Let_In A (fun _ => P)).

--- a/PerformanceExperiments/rewrite_under_binders_common.v
+++ b/PerformanceExperiments/rewrite_under_binders_common.v
@@ -17,8 +17,7 @@ Module Type LetInT.
   Notation "'dlet' x .. y := v 'in' f" := (Let_In v (fun x => .. (fun y => f) .. )).
   Axiom Let_In_nd_Proper : forall {A P},
       Proper (eq ==> pointwise_relation _ eq ==> eq) (@Let_In A (fun _ => P)).
-#[global]
-  Hint Extern 0 (Proper _ (@Let_In _ _)) => simple apply @Let_In_nd_Proper : typeclass_instances.
+  Global Hint Extern 0 (Proper _ (@Let_In _ _)) => simple apply @Let_In_nd_Proper : typeclass_instances.
 End LetInT.
 
 Module Export LetIn : LetInT.
@@ -27,8 +26,7 @@ Module Export LetIn : LetInT.
   Lemma Let_In_def : @Let_In = fun A P x f => let y := x in f y.
   Proof. reflexivity. Qed.
   Global Strategy 100 [Let_In].
-#[global]
-  Hint Opaque Let_In : rewrite.
+  Global Hint Opaque Let_In : rewrite.
   Global Instance Let_In_nd_Proper {A P}
     : Proper (eq ==> pointwise_relation _ eq ==> eq) (@Let_In A (fun _ => P)).
   Proof. cbv; intros; subst; auto. Qed.

--- a/PerformanceExperiments/rewrite_under_lets_plus_0.v
+++ b/PerformanceExperiments/rewrite_under_lets_plus_0.v
@@ -37,6 +37,7 @@ Ltac verify _ :=
     => is_var acc; verify_form acc lhs
   end.
 
+#[global]
 Hint Rewrite Z.add_0_r : mydb.
 
 Inductive rewrite_strat_kind := topdown | bottomup.
@@ -175,6 +176,7 @@ Ltac time_solve_goal2 := time_solve_goal constr:(kind_setoid_rewrite).
 Ltac run2 sz := Harness.runtests_verify_sanity (args_of_size (kind_setoid_rewrite)) describe_goal mkgoal2 redgoal time_solve_goal2 verify sz.
 
 
+#[global]
 Hint Opaque Let_In Z.add : rewrite typeclass_instances.
 Global Opaque Let_In Z.add.
 

--- a/PerformanceExperiments/rewrite_under_lets_plus_0.v
+++ b/PerformanceExperiments/rewrite_under_lets_plus_0.v
@@ -37,7 +37,6 @@ Ltac verify _ :=
     => is_var acc; verify_form acc lhs
   end.
 
-#[global]
 Hint Rewrite Z.add_0_r : mydb.
 
 Inductive rewrite_strat_kind := topdown | bottomup.
@@ -176,8 +175,7 @@ Ltac time_solve_goal2 := time_solve_goal constr:(kind_setoid_rewrite).
 Ltac run2 sz := Harness.runtests_verify_sanity (args_of_size (kind_setoid_rewrite)) describe_goal mkgoal2 redgoal time_solve_goal2 verify sz.
 
 
-#[global]
-Hint Opaque Let_In Z.add : rewrite typeclass_instances.
+Global Hint Opaque Let_In Z.add : rewrite typeclass_instances.
 Global Opaque Let_In Z.add.
 
 Global Instance : forall {A}, Proper (eq ==> eq ==> Basics.flip Basics.impl) (@eq A) := _.

--- a/PerformanceExperiments/typeclass_reification_let_in_HOAS.v
+++ b/PerformanceExperiments/typeclass_reification_let_in_HOAS.v
@@ -20,15 +20,22 @@ Axiom P : expr -> Prop.
 Axiom p : forall e, P e.
 
 Class reified_of (v : nat) (e : expr) := dummy : True.
+#[global]
 Hint Mode reified_of ! - : typeclass_instances.
+#[global]
 Instance reify_plus {x ex y ey} {_:reified_of x ex} {_:reified_of y ey}
   : reified_of (x + y) (Plus ex ey) := I.
+#[global]
 Instance reify_LetIn {x ex f ef} {_:reified_of x ex} {_:forall v ev, reified_of v (Var ev) -> reified_of (f v) (ef ev)}
   : reified_of (Let_In x f) (LetIn ex ef) := I.
+#[global]
 Instance reify_0 : reified_of 0 Zero := I.
+#[global]
 Instance reify_S {n en} {_:reified_of n en} : reified_of (S n) (Succ en) := I.
 Definition reify (v : nat) {ev : expr} {_ : reified_of v ev} := ev.
+#[global]
 Hint Extern 1 (reified_of _ ?ev) => progress cbv [ev] : typeclass_instances.
+#[global]
 Hint Extern 0 (reified_of _ _) => progress cbv [nested_lets] : typeclass_instances.
 Notation reified v := (match _ with e => match _ : reified_of v e with _ => e end end) (only parsing).
 

--- a/PerformanceExperiments/typeclass_reification_let_in_HOAS.v
+++ b/PerformanceExperiments/typeclass_reification_let_in_HOAS.v
@@ -20,23 +20,16 @@ Axiom P : expr -> Prop.
 Axiom p : forall e, P e.
 
 Class reified_of (v : nat) (e : expr) := dummy : True.
-#[global]
-Hint Mode reified_of ! - : typeclass_instances.
-#[global]
-Instance reify_plus {x ex y ey} {_:reified_of x ex} {_:reified_of y ey}
+Global Hint Mode reified_of ! - : typeclass_instances.
+Global Instance reify_plus {x ex y ey} {_:reified_of x ex} {_:reified_of y ey}
   : reified_of (x + y) (Plus ex ey) := I.
-#[global]
-Instance reify_LetIn {x ex f ef} {_:reified_of x ex} {_:forall v ev, reified_of v (Var ev) -> reified_of (f v) (ef ev)}
+Global Instance reify_LetIn {x ex f ef} {_:reified_of x ex} {_:forall v ev, reified_of v (Var ev) -> reified_of (f v) (ef ev)}
   : reified_of (Let_In x f) (LetIn ex ef) := I.
-#[global]
-Instance reify_0 : reified_of 0 Zero := I.
-#[global]
-Instance reify_S {n en} {_:reified_of n en} : reified_of (S n) (Succ en) := I.
+Global Instance reify_0 : reified_of 0 Zero := I.
+Global Instance reify_S {n en} {_:reified_of n en} : reified_of (S n) (Succ en) := I.
 Definition reify (v : nat) {ev : expr} {_ : reified_of v ev} := ev.
-#[global]
-Hint Extern 1 (reified_of _ ?ev) => progress cbv [ev] : typeclass_instances.
-#[global]
-Hint Extern 0 (reified_of _ _) => progress cbv [nested_lets] : typeclass_instances.
+Global Hint Extern 1 (reified_of _ ?ev) => progress cbv [ev] : typeclass_instances.
+Global Hint Extern 0 (reified_of _ _) => progress cbv [nested_lets] : typeclass_instances.
 Notation reified v := (match _ with e => match _ : reified_of v e with _ => e end end) (only parsing).
 
 Ltac mkgoal n := constr:(True).

--- a/PerformanceExperiments/typeclass_reification_let_in_PHOAS.v
+++ b/PerformanceExperiments/typeclass_reification_let_in_PHOAS.v
@@ -22,36 +22,25 @@ Axiom p : forall var t e, @P var t e.
 Ltac solve_P := intros; apply p.
 
 Class type_reified_of (v : Type) (t : type) := dummyT : True.
-#[global]
 Typeclasses Opaque type_reified_of.
-#[global]
-Hint Mode type_reified_of ! - : typeclass_instances.
-#[global]
-Instance reify_nat : type_reified_of nat NAT := I.
+Global Hint Mode type_reified_of ! - : typeclass_instances.
+Global Instance reify_nat : type_reified_of nat NAT := I.
 Class reified_of {var A B} (v : A) (e : @expr var B) := dummy : True.
-#[global]
 Typeclasses Opaque reified_of.
-#[global]
 Typeclasses Opaque Nat.add.
-#[global]
-Hint Mode reified_of - - - ! - : typeclass_instances.
-#[global]
-Instance reify_plus {var x ex y ey} {_:reified_of x ex} {_:reified_of y ey}
+Global Hint Mode reified_of - - - ! - : typeclass_instances.
+Global Instance reify_plus {var x ex y ey} {_:reified_of x ex} {_:reified_of y ey}
   : reified_of (x + y) (@Plus var ex ey) := I.
-#[global]
-Instance reify_LetIn {var A B tA tB x ex f ef} {_:reified_of x ex} {_:forall v ev, reified_of v (Var ev) -> reified_of (f v) (ef ev)}
+Global Instance reify_LetIn {var A B tA tB x ex f ef} {_:reified_of x ex} {_:forall v ev, reified_of v (Var ev) -> reified_of (f v) (ef ev)}
   : reified_of (@Let_In A (fun _ => B) x f) (@LetIn var tA tB ex ef) := I.
-#[global]
-Instance reify_0 {var} : reified_of 0 (@Zero var) := I.
-#[global]
-Instance reify_S {var n en} {_:reified_of n en} : reified_of (S n) (@Succ var en) := I.
+Global Instance reify_0 {var} : reified_of 0 (@Zero var) := I.
+Global Instance reify_S {var n en} {_:reified_of n en} : reified_of (S n) (@Succ var en) := I.
 Definition reify {var T T'} (v : T) {ev : @expr var T'} {_ : reified_of v ev} := ev.
 Ltac subst_evars :=
   repeat match goal with
          | [ x := ?e |- _ ] => is_evar e; subst x
          end.
-#[global]
-Hint Extern 0 (reified_of _ _) => progress (cbv [nested_lets]; subst_evars) : typeclass_instances.
+Global Hint Extern 0 (reified_of _ _) => progress (cbv [nested_lets]; subst_evars) : typeclass_instances.
 
 Notation reified var' v := (match _ return _ with t => match _ : @expr var' t return _ with e => match _ : reified_of v e with _ => e end end end) (only parsing).
 

--- a/PerformanceExperiments/typeclass_reification_let_in_PHOAS.v
+++ b/PerformanceExperiments/typeclass_reification_let_in_PHOAS.v
@@ -22,24 +22,35 @@ Axiom p : forall var t e, @P var t e.
 Ltac solve_P := intros; apply p.
 
 Class type_reified_of (v : Type) (t : type) := dummyT : True.
+#[global]
 Typeclasses Opaque type_reified_of.
+#[global]
 Hint Mode type_reified_of ! - : typeclass_instances.
+#[global]
 Instance reify_nat : type_reified_of nat NAT := I.
 Class reified_of {var A B} (v : A) (e : @expr var B) := dummy : True.
+#[global]
 Typeclasses Opaque reified_of.
+#[global]
 Typeclasses Opaque Nat.add.
+#[global]
 Hint Mode reified_of - - - ! - : typeclass_instances.
+#[global]
 Instance reify_plus {var x ex y ey} {_:reified_of x ex} {_:reified_of y ey}
   : reified_of (x + y) (@Plus var ex ey) := I.
+#[global]
 Instance reify_LetIn {var A B tA tB x ex f ef} {_:reified_of x ex} {_:forall v ev, reified_of v (Var ev) -> reified_of (f v) (ef ev)}
   : reified_of (@Let_In A (fun _ => B) x f) (@LetIn var tA tB ex ef) := I.
+#[global]
 Instance reify_0 {var} : reified_of 0 (@Zero var) := I.
+#[global]
 Instance reify_S {var n en} {_:reified_of n en} : reified_of (S n) (@Succ var en) := I.
 Definition reify {var T T'} (v : T) {ev : @expr var T'} {_ : reified_of v ev} := ev.
 Ltac subst_evars :=
   repeat match goal with
          | [ x := ?e |- _ ] => is_evar e; subst x
          end.
+#[global]
 Hint Extern 0 (reified_of _ _) => progress (cbv [nested_lets]; subst_evars) : typeclass_instances.
 
 Notation reified var' v := (match _ return _ with t => match _ : @expr var' t return _ with e => match _ : reified_of v e with _ => e end end end) (only parsing).

--- a/src/Makefile
+++ b/src/Makefile
@@ -51,8 +51,10 @@ else
 GREP_INVOCATION:=
 endif
 
+WARNINGS := -deprecated-hint-rewrite-without-locality,-deprecated-typeclasses-transparency-without-locality
+
 _CoqProject::
-	$(HIDE)(echo "-Q . CoqPerformanceTests"; ($(FILE_FINDER) "*.v" $(GREP_INVOCATION))) > $@
+	$(HIDE)(echo "-Q . CoqPerformanceTests"; echo '-arg -w -arg $(WARNINGS)'; ($(FILE_FINDER) "*.v" $(GREP_INVOCATION))) > $@
 
 Makefile.coq: _CoqProject
 	$(COQBIN)coq_makefile -f $< -o $@

--- a/src/fiat_crypto_via_setoid_rewrite_standalone.v
+++ b/src/fiat_crypto_via_setoid_rewrite_standalone.v
@@ -7,33 +7,24 @@ Import List.ListNotations.
 Local Open Scope Z_scope.
 Local Open Scope list_scope.
 
-#[global]
 Hint Rewrite <- pred_Sn : mydb.
 Lemma Z_of_nat_O : Z.of_nat 0 = 0. Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite Z_of_nat_O : mydb.
 Lemma Z_of_nat_S : forall x, Z.of_nat (S x) = Z.pos (Pos.of_succ_nat x). Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite Z_of_nat_S : mydb.
 Lemma fst_pair {A B} (a : A) (b : B) : fst (a, b) = a.
 Proof. reflexivity. Qed.
 Lemma snd_pair {A B} (a : A) (b : B) : snd (a, b) = b.
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite @fst_pair @snd_pair : mydb.
 Lemma Z_mul_pos_pos x y : Z.pos x * Z.pos y = Z.pos (x * y). Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite Z_mul_pos_pos : mydb.
-#[global]
 Hint Rewrite Z.mul_0_l Z.mul_0_r Z.opp_0 : mydb.
 Lemma Z_div_0_l_pos x : 0 / Z.pos x = 0. Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite Z_div_0_l_pos : mydb.
 Lemma Z_opp_pos x : Z.opp (Z.pos x) = Z.neg x. Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite Z_opp_pos : mydb.
 Lemma Z_opp_neg x : Z.opp (Z.neg x) = Z.pos x. Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite Z_opp_neg : mydb.
 Definition Z_div_unfolded := Eval cbv in Z.div.
 Lemma unfold_Z_div_pos_pos x y : Z.div (Z.pos x) (Z.pos y) = Z_div_unfolded (Z.pos x) (Z.pos y).
@@ -44,63 +35,45 @@ Lemma unfold_Z_div_neg_pos x y : Z.div (Z.neg x) (Z.pos y) = Z_div_unfolded (Z.n
 Proof. reflexivity. Qed.
 Lemma unfold_Z_div_neg_neg x y : Z.div (Z.neg x) (Z.neg y) = Z_div_unfolded (Z.neg x) (Z.neg y).
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite unfold_Z_div_neg_neg unfold_Z_div_neg_pos unfold_Z_div_pos_neg unfold_Z_div_pos_pos : mydb.
-#[global]
 Hint Rewrite Z.pow_0_r : mydb.
 Definition Z_pow_unfolded := Eval cbv in Z.pow.
 Lemma Z_pow_pos_pos x y : Z.pow (Z.pos x) (Z.pos y) = Z_pow_unfolded (Z.pos x) (Z.pos y). Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite Z_pow_pos_pos : mydb.
 Lemma app_cons A (x : A) xs ys : (x :: xs) ++ ys = x :: (xs ++ ys).
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite app_cons : mydb.
 Lemma app_nil A xs : @nil A ++ xs = xs.
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite app_nil : mydb.
 Lemma partition_cons A f x xs : @partition A f (x :: xs) = prod_rect (fun _ => _) (fun g d => if f x then (x :: g, d) else (g, x :: d)) (partition f xs).
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite partition_cons : mydb.
 Lemma partition_nil A f : @partition A f nil = (nil, nil). Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite partition_nil : mydb.
 Lemma prod_rect_pair A B P f x y : @prod_rect A B P f (x, y) = f x y. Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite prod_rect_pair : mydb.
 Definition Z_modulo_unfolded := Eval cbv in Z.modulo.
 Lemma Z_modulo_pos_pos x y : Z.modulo (Z.pos x) (Z.pos y) = Z_modulo_unfolded (Z.pos x) (Z.pos y).
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite Z_modulo_pos_pos : mydb.
-#[global]
 Hint Rewrite Z.eqb_refl Nat.eqb_refl : mydb.
 Definition Pos_eqb_unfolded := Eval cbv in Pos.eqb.
 Lemma Z_eqb_pos_pos x y : Z.eqb (Z.pos x) (Z.pos y) = Pos_eqb_unfolded x y. Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite Z_eqb_pos_pos : mydb.
 Lemma Z_eqb_neg_neg x y : Z.eqb (Z.neg x) (Z.neg y) = Pos_eqb_unfolded x y. Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite Z_eqb_neg_neg : mydb.
 Lemma Z_eqb_pos_0 x : Z.eqb (Z.pos x) 0 = false. Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite Z_eqb_pos_0 : mydb.
 Lemma Z_eqb_0_pos x : Z.eqb 0 (Z.pos x) = false. Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite Z_eqb_0_pos : mydb.
 Lemma Z_eqb_pos_neg x y : Z.eqb (Z.pos x) (Z.neg y) = false. Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite Z_eqb_pos_neg : mydb.
 Lemma Z_eqb_neg_pos y x : Z.eqb (Z.neg y) (Z.pos x) = false. Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite Z_eqb_neg_pos : mydb.
 Lemma Z_eqb_neg_0 x : Z.eqb (Z.neg x) 0 = false. Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite Z_eqb_neg_0 : mydb.
 Lemma Z_eqb_0_neg x : Z.eqb 0 (Z.neg x) = false. Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite Z_eqb_0_neg : mydb.
 Lemma length_nil A : List.length (@nil A) = 0%nat. Proof. reflexivity. Qed.
 Lemma map_cons A B (f : A -> B) (x : A) (l : list A) : List.map f (x :: l) = f x :: List.map f l.
@@ -109,25 +82,20 @@ Lemma map_nil A B (f : A -> B) : List.map f [] = [].
 Proof. reflexivity. Qed.
 Lemma length_cons {T} (x : T) (xs : list T) : Datatypes.length (x :: xs) = S (Datatypes.length xs).
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite map_cons map_nil @length_cons length_nil : mydb.
 Lemma flat_map_cons {A B} (f : A -> list B) (x : A) (xs : list A) : flat_map f (x :: xs) = (f x ++ flat_map f xs)%list.
 Proof. reflexivity. Qed.
 Lemma flat_map_nil {A B} (f : A -> list B) : flat_map f [] = [].
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite @flat_map_cons @flat_map_nil : mydb.
 Lemma nat_eqb_S_O x : Nat.eqb (S x) O = false. Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite nat_eqb_S_O : mydb.
 Lemma nat_eqb_O_S x : Nat.eqb O (S x) = false. Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite nat_eqb_O_S : mydb.
 Lemma fold_right_cons {A B} (f : B -> A -> A) (a : A) (b : B) (bs : list B) : fold_right f a (b :: bs) = f b (fold_right f a bs).
 Proof. reflexivity. Qed.
 Lemma fold_right_nil {A B : Type} (f : B -> A -> A) (a : A) : fold_right f a [] = a.
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite @fold_right_cons @fold_right_nil : mydb.
 Reserved Notation "'dlet' x .. y := v 'in' f"
          (at level 200, x binder, y binder, f at level 200, format "'dlet'  x .. y  :=  v  'in' '//' f").
@@ -152,8 +120,7 @@ Global Instance Proper_Let_In_nd_changevalue_forall {A B} {RB:relation B}
 Proof. cbv; intuition (subst; eauto). Qed.
 
 (* Strangely needed in some cases where we have [(fun _ => foo) ...] messing up dependency calculation *)
-#[global]
-Hint Extern 1 (Proper _ (@Let_In _ _)) => progress cbv beta : typeclass_instances.
+Global Hint Extern 1 (Proper _ (@Let_In _ _)) => progress cbv beta : typeclass_instances.
 
 Definition app_Let_In_nd {A B T} (f:B->T) (e:A) (C:A->B)
   : f (Let_In e C) = Let_In e (fun v => f (C v)) := eq_refl.
@@ -165,31 +132,25 @@ Lemma unfold_Let_In {A B} v f : @Let_In A B v f = f v.
 Proof. reflexivity. Qed.
 Lemma dlet_pair A B T x y f : Let_In (@pair A B x y) f = (dlet x' := x in dlet y' := y in f (x', y')) :> T.
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite dlet_pair : mydb letdb.
 Lemma lift_dlet A B C x (f : A -> B) (g : B -> C) : g (Let_In x f) = Let_In x (fun x' => g (f x')). Proof. reflexivity. Qed.
 Definition lift_dlet_list A B C := @lift_dlet A B (list C).
 Definition lift_dlet_prod A B C1 C2 := @lift_dlet A B (C1 * C2).
 Definition lift_dlet_nat A B := @lift_dlet A B nat.
 Definition lift_dlet_Z A B := @lift_dlet A B Z.
-#[global]
 Hint Rewrite lift_dlet_list lift_dlet_prod lift_dlet_nat lift_dlet_Z : mydb letdb.
 Lemma lift_dlet1 A B C D x y (f : A -> B) (g : B -> C -> D) : g (Let_In x f) y = Let_In x (fun x' => g (f x') y). Proof. reflexivity. Qed.
 Definition lift_dlet1_list A B C D := @lift_dlet1 A B C (list D).
 Definition lift_dlet1_prod A B C D1 D2 := @lift_dlet1 A B C (D1 * D2).
 Definition lift_dlet1_nat A B C := @lift_dlet1 A B C nat.
 Definition lift_dlet1_Z A B C := @lift_dlet1 A B C Z.
-#[global]
 Hint Rewrite lift_dlet1_list lift_dlet1_prod lift_dlet1_nat lift_dlet1_Z : mydb letdb.
 Lemma inline_dlet_S B x (f : nat -> B) : Let_In (S x) f = f (S x). Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite inline_dlet_S : mydb letdb.
 Lemma inline_dlet_O B (f : nat -> B) : Let_In O f = f O. Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite inline_dlet_O : mydb letdb.
 Lemma rev_nil A : rev (@nil A) = nil. Proof. reflexivity. Qed.
 Lemma rev_cons {A} x ls : @rev A (x :: ls) = rev ls ++ [x]. Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite @rev_cons @rev_nil : mydb.
 Fixpoint update_nth {T} n f (xs:list T) {struct n} :=
         match n with
@@ -206,11 +167,9 @@ Lemma update_nth_nil : forall {T} n f, update_nth n f (@nil T) = @nil T.
 Proof. destruct n; reflexivity. Qed.
 Lemma update_nth_cons : forall {T} f (u0 : T) us, update_nth 0 f (u0 :: us) = (f u0) :: us.
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite @update_nth_nil @update_nth_cons : mydb.
 Lemma update_nth_S_cons T n f x xs : @update_nth T (S n) f (x :: xs) = x :: update_nth n f xs.
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite update_nth_S_cons : mydb.
 Lemma combine_cons : forall {A B} a b (xs:list A) (ys:list B),
   combine (a :: xs) (b :: ys) = (a,b) :: combine xs ys.
@@ -218,11 +177,9 @@ Proof. reflexivity. Qed.
 Lemma combine_nil_r : forall {A B} (xs:list A),
   combine xs (@nil B) = nil.
 Proof. destruct xs; reflexivity. Qed.
-#[global]
 Hint Rewrite @combine_cons @combine_nil_r : mydb.
 Lemma app_dlet A B x (f : A -> list B) ys : (Let_In x f) ++ ys = Let_In x (fun x' => f x' ++ ys).
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite app_dlet : mydb letdb.
 Definition expand_list_helper {A} (default : A) (ls : list A) (n : nat) (idx : nat) : list A
   := nat_rect
@@ -338,43 +295,33 @@ Lemma split_cons s p ps : Associational.split s (p :: ps) = prod_rect (fun _ => 
 Proof.
   cbv [Associational.split prod_rect]; edestruct partition; reflexivity.
 Qed.
-#[global]
 Hint Rewrite split_cons : mydb.
 Lemma mul_cons_cons p ps q qs : Associational.mul (p :: ps) (q :: qs) = flat_map (fun t : Z * Z => List.map (fun t' : Z * Z => (fst t * fst t', snd t * snd t')) (q :: qs)) (p :: ps).
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite mul_cons_cons : mydb.
 Lemma mul_cons_nil p ps : Associational.mul (p :: ps) nil = flat_map (fun t : Z * Z => List.map (fun t' : Z * Z => (fst t * fst t', snd t * snd t')) nil) (p :: ps).
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite mul_cons_nil : mydb.
 Lemma mul_nil_cons q qs : Associational.mul nil (q :: qs) = flat_map (fun t : Z * Z => List.map (fun t' : Z * Z => (fst t * fst t', snd t * snd t')) (q :: qs)) nil.
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite mul_nil_cons : mydb.
 Lemma mul_nil_nil : Associational.mul nil nil = flat_map (fun t : Z * Z => List.map (fun t' : Z * Z => (fst t * fst t', snd t * snd t')) nil) nil.
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite mul_nil_nil : mydb.
 Lemma unfold_reduce s c p : Associational.reduce s c p = prod_rect (fun _ => _) (fun lo hi => lo ++ Associational.mul c hi) (Associational.split s p).
 Proof. cbv [Associational.reduce]; edestruct Associational.split; reflexivity. Qed.
-#[global]
 Hint Rewrite unfold_reduce : mydb.
 Lemma nat_rect_O P fO fS : nat_rect P fO fS 0 = fO.
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite nat_rect_O : mydb.
 Lemma nat_rect_O_arr P Q fO fS x : nat_rect (fun n => P n -> Q n) fO fS 0 x = fO x.
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite nat_rect_O_arr : mydb.
 Lemma nat_rect_S P fO fS n : nat_rect P fO fS (S n) = fS n (nat_rect P fO fS n).
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite nat_rect_S : mydb.
 Lemma nat_rect_S_arr P Q fO fS n x : nat_rect (fun n => P n -> Q n) fO fS (S n) x = fS n (nat_rect _ fO fS n) x.
 Proof. reflexivity. Qed.
-#[global]
 Hint Rewrite nat_rect_S_arr : mydb.
 Lemma pointwise_map {A B} : Proper ((pointwise_relation _ eq) ==> eq ==> eq) (@List.map A B).
 Proof.
@@ -428,8 +375,7 @@ Ltac solve_Proper_eq :=
       unify R R';
       apply (@reflexive_proper A R')
   end.
-#[global]
-Hint Extern 0 (Proper _ _) => solve_Proper_eq : typeclass_instances.
+Global Hint Extern 0 (Proper _ _) => solve_Proper_eq : typeclass_instances.
 
 Declare Reduction mycbv := cbv [Pos.of_succ_nat Pos.succ Pos.mul Pos.add Z_div_unfolded Z_pow_unfolded Z_modulo_unfolded Pos_eqb_unfolded].
 Ltac mycbv := cbv [Pos.of_succ_nat Pos.succ Pos.mul Pos.add Z_div_unfolded Z_pow_unfolded Z_modulo_unfolded Pos_eqb_unfolded].
@@ -438,8 +384,7 @@ Declare Reduction morecbv := cbv [Associational.repeat_reduce Positional.from_as
 Ltac morecbv := cbv [Associational.repeat_reduce Positional.from_associational Positional.zeros repeat Positional.place Positional.chained_carries Positional.add_to_nth Positional.carry_reduce Positional.carry Positional.to_associational seq Associational.carry Associational.carryterm].
 
 Opaque Let_In.
-#[global]
-Hint Constants Opaque : rewrite.
+Global Hint Constants Opaque : rewrite.
 
 Global Instance flat_map_Proper A B : Proper (pointwise_relation _ eq ==> eq ==> eq) (@flat_map A B).
 Proof. Admitted.
@@ -466,10 +411,8 @@ Global Instance: forall A B, Proper (eq ==> eq ==> eq) (@pair A B) := _.
 Global Instance: forall A B P, Proper (pointwise_relation _ (pointwise_relation _ eq) ==> eq ==> eq) (@prod_rect A B (fun _ => P)).
 Proof. intros ? ? ? f g Hfg [? ?] ? ?; subst; apply Hfg. Qed.
 Global Instance: Transitive (Basics.flip Basics.impl) := _.
-#[global]
-Existing Instance pointwise_map.
-#[global]
-Existing Instance fold_right_Proper.
+Global Existing Instance pointwise_map.
+Global Existing Instance fold_right_Proper.
 Global Instance: forall A B, Proper (forall_relation (fun _ => pointwise_relation _ eq) ==> eq ==> eq ==> eq) (@fold_right A B).
 Proof. intros ? ? f g Hfg. apply fold_right_Proper, Hfg. Qed.
 Global Instance: forall A B x, (Proper (pointwise_relation _ eq ==> eq) (@Let_In A (fun _ => B) x)) := _.

--- a/src/fiat_crypto_via_setoid_rewrite_standalone.v
+++ b/src/fiat_crypto_via_setoid_rewrite_standalone.v
@@ -7,24 +7,33 @@ Import List.ListNotations.
 Local Open Scope Z_scope.
 Local Open Scope list_scope.
 
+#[global]
 Hint Rewrite <- pred_Sn : mydb.
 Lemma Z_of_nat_O : Z.of_nat 0 = 0. Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite Z_of_nat_O : mydb.
 Lemma Z_of_nat_S : forall x, Z.of_nat (S x) = Z.pos (Pos.of_succ_nat x). Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite Z_of_nat_S : mydb.
 Lemma fst_pair {A B} (a : A) (b : B) : fst (a, b) = a.
 Proof. reflexivity. Qed.
 Lemma snd_pair {A B} (a : A) (b : B) : snd (a, b) = b.
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite @fst_pair @snd_pair : mydb.
 Lemma Z_mul_pos_pos x y : Z.pos x * Z.pos y = Z.pos (x * y). Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite Z_mul_pos_pos : mydb.
+#[global]
 Hint Rewrite Z.mul_0_l Z.mul_0_r Z.opp_0 : mydb.
 Lemma Z_div_0_l_pos x : 0 / Z.pos x = 0. Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite Z_div_0_l_pos : mydb.
 Lemma Z_opp_pos x : Z.opp (Z.pos x) = Z.neg x. Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite Z_opp_pos : mydb.
 Lemma Z_opp_neg x : Z.opp (Z.neg x) = Z.pos x. Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite Z_opp_neg : mydb.
 Definition Z_div_unfolded := Eval cbv in Z.div.
 Lemma unfold_Z_div_pos_pos x y : Z.div (Z.pos x) (Z.pos y) = Z_div_unfolded (Z.pos x) (Z.pos y).
@@ -35,45 +44,63 @@ Lemma unfold_Z_div_neg_pos x y : Z.div (Z.neg x) (Z.pos y) = Z_div_unfolded (Z.n
 Proof. reflexivity. Qed.
 Lemma unfold_Z_div_neg_neg x y : Z.div (Z.neg x) (Z.neg y) = Z_div_unfolded (Z.neg x) (Z.neg y).
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite unfold_Z_div_neg_neg unfold_Z_div_neg_pos unfold_Z_div_pos_neg unfold_Z_div_pos_pos : mydb.
+#[global]
 Hint Rewrite Z.pow_0_r : mydb.
 Definition Z_pow_unfolded := Eval cbv in Z.pow.
 Lemma Z_pow_pos_pos x y : Z.pow (Z.pos x) (Z.pos y) = Z_pow_unfolded (Z.pos x) (Z.pos y). Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite Z_pow_pos_pos : mydb.
 Lemma app_cons A (x : A) xs ys : (x :: xs) ++ ys = x :: (xs ++ ys).
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite app_cons : mydb.
 Lemma app_nil A xs : @nil A ++ xs = xs.
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite app_nil : mydb.
 Lemma partition_cons A f x xs : @partition A f (x :: xs) = prod_rect (fun _ => _) (fun g d => if f x then (x :: g, d) else (g, x :: d)) (partition f xs).
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite partition_cons : mydb.
 Lemma partition_nil A f : @partition A f nil = (nil, nil). Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite partition_nil : mydb.
 Lemma prod_rect_pair A B P f x y : @prod_rect A B P f (x, y) = f x y. Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite prod_rect_pair : mydb.
 Definition Z_modulo_unfolded := Eval cbv in Z.modulo.
 Lemma Z_modulo_pos_pos x y : Z.modulo (Z.pos x) (Z.pos y) = Z_modulo_unfolded (Z.pos x) (Z.pos y).
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite Z_modulo_pos_pos : mydb.
+#[global]
 Hint Rewrite Z.eqb_refl Nat.eqb_refl : mydb.
 Definition Pos_eqb_unfolded := Eval cbv in Pos.eqb.
 Lemma Z_eqb_pos_pos x y : Z.eqb (Z.pos x) (Z.pos y) = Pos_eqb_unfolded x y. Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite Z_eqb_pos_pos : mydb.
 Lemma Z_eqb_neg_neg x y : Z.eqb (Z.neg x) (Z.neg y) = Pos_eqb_unfolded x y. Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite Z_eqb_neg_neg : mydb.
 Lemma Z_eqb_pos_0 x : Z.eqb (Z.pos x) 0 = false. Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite Z_eqb_pos_0 : mydb.
 Lemma Z_eqb_0_pos x : Z.eqb 0 (Z.pos x) = false. Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite Z_eqb_0_pos : mydb.
 Lemma Z_eqb_pos_neg x y : Z.eqb (Z.pos x) (Z.neg y) = false. Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite Z_eqb_pos_neg : mydb.
 Lemma Z_eqb_neg_pos y x : Z.eqb (Z.neg y) (Z.pos x) = false. Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite Z_eqb_neg_pos : mydb.
 Lemma Z_eqb_neg_0 x : Z.eqb (Z.neg x) 0 = false. Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite Z_eqb_neg_0 : mydb.
 Lemma Z_eqb_0_neg x : Z.eqb 0 (Z.neg x) = false. Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite Z_eqb_0_neg : mydb.
 Lemma length_nil A : List.length (@nil A) = 0%nat. Proof. reflexivity. Qed.
 Lemma map_cons A B (f : A -> B) (x : A) (l : list A) : List.map f (x :: l) = f x :: List.map f l.
@@ -82,20 +109,25 @@ Lemma map_nil A B (f : A -> B) : List.map f [] = [].
 Proof. reflexivity. Qed.
 Lemma length_cons {T} (x : T) (xs : list T) : Datatypes.length (x :: xs) = S (Datatypes.length xs).
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite map_cons map_nil @length_cons length_nil : mydb.
 Lemma flat_map_cons {A B} (f : A -> list B) (x : A) (xs : list A) : flat_map f (x :: xs) = (f x ++ flat_map f xs)%list.
 Proof. reflexivity. Qed.
 Lemma flat_map_nil {A B} (f : A -> list B) : flat_map f [] = [].
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite @flat_map_cons @flat_map_nil : mydb.
 Lemma nat_eqb_S_O x : Nat.eqb (S x) O = false. Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite nat_eqb_S_O : mydb.
 Lemma nat_eqb_O_S x : Nat.eqb O (S x) = false. Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite nat_eqb_O_S : mydb.
 Lemma fold_right_cons {A B} (f : B -> A -> A) (a : A) (b : B) (bs : list B) : fold_right f a (b :: bs) = f b (fold_right f a bs).
 Proof. reflexivity. Qed.
 Lemma fold_right_nil {A B : Type} (f : B -> A -> A) (a : A) : fold_right f a [] = a.
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite @fold_right_cons @fold_right_nil : mydb.
 Reserved Notation "'dlet' x .. y := v 'in' f"
          (at level 200, x binder, y binder, f at level 200, format "'dlet'  x .. y  :=  v  'in' '//' f").
@@ -120,6 +152,7 @@ Global Instance Proper_Let_In_nd_changevalue_forall {A B} {RB:relation B}
 Proof. cbv; intuition (subst; eauto). Qed.
 
 (* Strangely needed in some cases where we have [(fun _ => foo) ...] messing up dependency calculation *)
+#[global]
 Hint Extern 1 (Proper _ (@Let_In _ _)) => progress cbv beta : typeclass_instances.
 
 Definition app_Let_In_nd {A B T} (f:B->T) (e:A) (C:A->B)
@@ -132,25 +165,31 @@ Lemma unfold_Let_In {A B} v f : @Let_In A B v f = f v.
 Proof. reflexivity. Qed.
 Lemma dlet_pair A B T x y f : Let_In (@pair A B x y) f = (dlet x' := x in dlet y' := y in f (x', y')) :> T.
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite dlet_pair : mydb letdb.
 Lemma lift_dlet A B C x (f : A -> B) (g : B -> C) : g (Let_In x f) = Let_In x (fun x' => g (f x')). Proof. reflexivity. Qed.
 Definition lift_dlet_list A B C := @lift_dlet A B (list C).
 Definition lift_dlet_prod A B C1 C2 := @lift_dlet A B (C1 * C2).
 Definition lift_dlet_nat A B := @lift_dlet A B nat.
 Definition lift_dlet_Z A B := @lift_dlet A B Z.
+#[global]
 Hint Rewrite lift_dlet_list lift_dlet_prod lift_dlet_nat lift_dlet_Z : mydb letdb.
 Lemma lift_dlet1 A B C D x y (f : A -> B) (g : B -> C -> D) : g (Let_In x f) y = Let_In x (fun x' => g (f x') y). Proof. reflexivity. Qed.
 Definition lift_dlet1_list A B C D := @lift_dlet1 A B C (list D).
 Definition lift_dlet1_prod A B C D1 D2 := @lift_dlet1 A B C (D1 * D2).
 Definition lift_dlet1_nat A B C := @lift_dlet1 A B C nat.
 Definition lift_dlet1_Z A B C := @lift_dlet1 A B C Z.
+#[global]
 Hint Rewrite lift_dlet1_list lift_dlet1_prod lift_dlet1_nat lift_dlet1_Z : mydb letdb.
 Lemma inline_dlet_S B x (f : nat -> B) : Let_In (S x) f = f (S x). Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite inline_dlet_S : mydb letdb.
 Lemma inline_dlet_O B (f : nat -> B) : Let_In O f = f O. Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite inline_dlet_O : mydb letdb.
 Lemma rev_nil A : rev (@nil A) = nil. Proof. reflexivity. Qed.
 Lemma rev_cons {A} x ls : @rev A (x :: ls) = rev ls ++ [x]. Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite @rev_cons @rev_nil : mydb.
 Fixpoint update_nth {T} n f (xs:list T) {struct n} :=
         match n with
@@ -167,9 +206,11 @@ Lemma update_nth_nil : forall {T} n f, update_nth n f (@nil T) = @nil T.
 Proof. destruct n; reflexivity. Qed.
 Lemma update_nth_cons : forall {T} f (u0 : T) us, update_nth 0 f (u0 :: us) = (f u0) :: us.
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite @update_nth_nil @update_nth_cons : mydb.
 Lemma update_nth_S_cons T n f x xs : @update_nth T (S n) f (x :: xs) = x :: update_nth n f xs.
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite update_nth_S_cons : mydb.
 Lemma combine_cons : forall {A B} a b (xs:list A) (ys:list B),
   combine (a :: xs) (b :: ys) = (a,b) :: combine xs ys.
@@ -177,9 +218,11 @@ Proof. reflexivity. Qed.
 Lemma combine_nil_r : forall {A B} (xs:list A),
   combine xs (@nil B) = nil.
 Proof. destruct xs; reflexivity. Qed.
+#[global]
 Hint Rewrite @combine_cons @combine_nil_r : mydb.
 Lemma app_dlet A B x (f : A -> list B) ys : (Let_In x f) ++ ys = Let_In x (fun x' => f x' ++ ys).
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite app_dlet : mydb letdb.
 Definition expand_list_helper {A} (default : A) (ls : list A) (n : nat) (idx : nat) : list A
   := nat_rect
@@ -295,33 +338,43 @@ Lemma split_cons s p ps : Associational.split s (p :: ps) = prod_rect (fun _ => 
 Proof.
   cbv [Associational.split prod_rect]; edestruct partition; reflexivity.
 Qed.
+#[global]
 Hint Rewrite split_cons : mydb.
 Lemma mul_cons_cons p ps q qs : Associational.mul (p :: ps) (q :: qs) = flat_map (fun t : Z * Z => List.map (fun t' : Z * Z => (fst t * fst t', snd t * snd t')) (q :: qs)) (p :: ps).
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite mul_cons_cons : mydb.
 Lemma mul_cons_nil p ps : Associational.mul (p :: ps) nil = flat_map (fun t : Z * Z => List.map (fun t' : Z * Z => (fst t * fst t', snd t * snd t')) nil) (p :: ps).
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite mul_cons_nil : mydb.
 Lemma mul_nil_cons q qs : Associational.mul nil (q :: qs) = flat_map (fun t : Z * Z => List.map (fun t' : Z * Z => (fst t * fst t', snd t * snd t')) (q :: qs)) nil.
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite mul_nil_cons : mydb.
 Lemma mul_nil_nil : Associational.mul nil nil = flat_map (fun t : Z * Z => List.map (fun t' : Z * Z => (fst t * fst t', snd t * snd t')) nil) nil.
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite mul_nil_nil : mydb.
 Lemma unfold_reduce s c p : Associational.reduce s c p = prod_rect (fun _ => _) (fun lo hi => lo ++ Associational.mul c hi) (Associational.split s p).
 Proof. cbv [Associational.reduce]; edestruct Associational.split; reflexivity. Qed.
+#[global]
 Hint Rewrite unfold_reduce : mydb.
 Lemma nat_rect_O P fO fS : nat_rect P fO fS 0 = fO.
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite nat_rect_O : mydb.
 Lemma nat_rect_O_arr P Q fO fS x : nat_rect (fun n => P n -> Q n) fO fS 0 x = fO x.
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite nat_rect_O_arr : mydb.
 Lemma nat_rect_S P fO fS n : nat_rect P fO fS (S n) = fS n (nat_rect P fO fS n).
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite nat_rect_S : mydb.
 Lemma nat_rect_S_arr P Q fO fS n x : nat_rect (fun n => P n -> Q n) fO fS (S n) x = fS n (nat_rect _ fO fS n) x.
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite nat_rect_S_arr : mydb.
 Lemma pointwise_map {A B} : Proper ((pointwise_relation _ eq) ==> eq ==> eq) (@List.map A B).
 Proof.
@@ -375,6 +428,7 @@ Ltac solve_Proper_eq :=
       unify R R';
       apply (@reflexive_proper A R')
   end.
+#[global]
 Hint Extern 0 (Proper _ _) => solve_Proper_eq : typeclass_instances.
 
 Declare Reduction mycbv := cbv [Pos.of_succ_nat Pos.succ Pos.mul Pos.add Z_div_unfolded Z_pow_unfolded Z_modulo_unfolded Pos_eqb_unfolded].
@@ -384,6 +438,7 @@ Declare Reduction morecbv := cbv [Associational.repeat_reduce Positional.from_as
 Ltac morecbv := cbv [Associational.repeat_reduce Positional.from_associational Positional.zeros repeat Positional.place Positional.chained_carries Positional.add_to_nth Positional.carry_reduce Positional.carry Positional.to_associational seq Associational.carry Associational.carryterm].
 
 Opaque Let_In.
+#[global]
 Hint Constants Opaque : rewrite.
 
 Global Instance flat_map_Proper A B : Proper (pointwise_relation _ eq ==> eq ==> eq) (@flat_map A B).
@@ -411,7 +466,9 @@ Global Instance: forall A B, Proper (eq ==> eq ==> eq) (@pair A B) := _.
 Global Instance: forall A B P, Proper (pointwise_relation _ (pointwise_relation _ eq) ==> eq ==> eq) (@prod_rect A B (fun _ => P)).
 Proof. intros ? ? ? f g Hfg [? ?] ? ?; subst; apply Hfg. Qed.
 Global Instance: Transitive (Basics.flip Basics.impl) := _.
+#[global]
 Existing Instance pointwise_map.
+#[global]
 Existing Instance fold_right_Proper.
 Global Instance: forall A B, Proper (forall_relation (fun _ => pointwise_relation _ eq) ==> eq ==> eq ==> eq) (@fold_right A B).
 Proof. intros ? ? f g Hfg. apply fold_right_Proper, Hfg. Qed.

--- a/src/typeclass_reification_common.v
+++ b/src/typeclass_reification_common.v
@@ -21,36 +21,25 @@ Axiom p : forall var t e, @P var t e.
 Ltac solve_P := intros; apply p.
 
 Class type_reified_of (v : Type) (t : type) := dummyT : True.
-#[global]
 Typeclasses Opaque type_reified_of.
-#[global]
-Hint Mode type_reified_of ! - : typeclass_instances.
-#[global]
-Instance reify_nat : type_reified_of nat NAT := I.
+Global Hint Mode type_reified_of ! - : typeclass_instances.
+Global Instance reify_nat : type_reified_of nat NAT := I.
 Class reified_of {var A B} (v : A) (e : @expr var B) := dummy : True.
-#[global]
 Typeclasses Opaque reified_of.
-#[global]
 Typeclasses Opaque Nat.add.
-#[global]
-Hint Mode reified_of - - - ! - : typeclass_instances.
-#[global]
-Instance reify_plus {var x ex y ey} {_:reified_of x ex} {_:reified_of y ey}
+Global Hint Mode reified_of - - - ! - : typeclass_instances.
+Global Instance reify_plus {var x ex y ey} {_:reified_of x ex} {_:reified_of y ey}
   : reified_of (x + y) (@Plus var ex ey) := I.
-#[global]
-Instance reify_LetIn {var A B tA tB x ex f ef} {_:reified_of x ex} {_:forall v ev, reified_of v (Var ev) -> reified_of (f v) (ef ev)}
+Global Instance reify_LetIn {var A B tA tB x ex f ef} {_:reified_of x ex} {_:forall v ev, reified_of v (Var ev) -> reified_of (f v) (ef ev)}
   : reified_of (@Let_In A (fun _ => B) x f) (@LetIn var tA tB ex ef) := I.
-#[global]
-Instance reify_0 {var} : reified_of 0 (@Zero var) := I.
-#[global]
-Instance reify_S {var n en} {_:reified_of n en} : reified_of (S n) (@Succ var en) := I.
+Global Instance reify_0 {var} : reified_of 0 (@Zero var) := I.
+Global Instance reify_S {var n en} {_:reified_of n en} : reified_of (S n) (@Succ var en) := I.
 Definition reify {var T T'} (v : T) {ev : @expr var T'} {_ : reified_of v ev} := ev.
 Ltac subst_evars :=
   repeat match goal with
          | [ x := ?e |- _ ] => is_evar e; subst x
          end.
-#[global]
-Hint Extern 0 (reified_of _ _) => progress (cbv [nested_lets]; subst_evars) : typeclass_instances.
+Global Hint Extern 0 (reified_of _ _) => progress (cbv [nested_lets]; subst_evars) : typeclass_instances.
 
 Notation reified var' v := (match _ return _ with t => match _ : @expr var' t return _ with e => match _ : reified_of v e with _ => e end end end) (only parsing).
 

--- a/src/typeclass_reification_common.v
+++ b/src/typeclass_reification_common.v
@@ -21,24 +21,35 @@ Axiom p : forall var t e, @P var t e.
 Ltac solve_P := intros; apply p.
 
 Class type_reified_of (v : Type) (t : type) := dummyT : True.
+#[global]
 Typeclasses Opaque type_reified_of.
+#[global]
 Hint Mode type_reified_of ! - : typeclass_instances.
+#[global]
 Instance reify_nat : type_reified_of nat NAT := I.
 Class reified_of {var A B} (v : A) (e : @expr var B) := dummy : True.
+#[global]
 Typeclasses Opaque reified_of.
+#[global]
 Typeclasses Opaque Nat.add.
+#[global]
 Hint Mode reified_of - - - ! - : typeclass_instances.
+#[global]
 Instance reify_plus {var x ex y ey} {_:reified_of x ex} {_:reified_of y ey}
   : reified_of (x + y) (@Plus var ex ey) := I.
+#[global]
 Instance reify_LetIn {var A B tA tB x ex f ef} {_:reified_of x ex} {_:forall v ev, reified_of v (Var ev) -> reified_of (f v) (ef ev)}
   : reified_of (@Let_In A (fun _ => B) x f) (@LetIn var tA tB ex ef) := I.
+#[global]
 Instance reify_0 {var} : reified_of 0 (@Zero var) := I.
+#[global]
 Instance reify_S {var n en} {_:reified_of n en} : reified_of (S n) (@Succ var en) := I.
 Definition reify {var T T'} (v : T) {ev : @expr var T'} {_ : reified_of v ev} := ev.
 Ltac subst_evars :=
   repeat match goal with
          | [ x := ?e |- _ ] => is_evar e; subst x
          end.
+#[global]
 Hint Extern 0 (reified_of _ _) => progress (cbv [nested_lets]; subst_evars) : typeclass_instances.
 
 Notation reified var' v := (match _ return _ with t => match _ : @expr var' t return _ with e => match _ : reified_of v e with _ => e end end end) (only parsing).


### PR DESCRIPTION
This makes non-rewrite hints global and ensures that rewrite hints are always exported appropriately.

Thanks @ppedrot for #21, it was helpful in making this more-backwards-compatible PR

Supercedes and closes #21