### PR TITLE
Disable typeclass debug

### DIFF
--- a/src/fiat_crypto_via_setoid_rewrite_standalone.v
+++ b/src/fiat_crypto_via_setoid_rewrite_standalone.v
@@ -959,7 +959,7 @@ Chars 36642 - 36738 [(time~"goal_of_size~5"~~~try~~...] 31132.252 secs (31123.83
 
 Set Ltac Profiling.
 Set Printing Depth 1000000.
-Set Typeclasses Debug.
+(*Set Typeclasses Debug.*)
 Set Printing Width 1000000.
 
 (* sanity check *)


### PR DESCRIPTION
Fixes https://github.com/coq/coq/issues/18083

I wish there were versions of `Time` and `Timeout` that were about constraining the size of typeclass resolution.